### PR TITLE
feat: add a new Widget Segment Radial Gauge, adjust Scale Radial Gauge for negative minValue usage

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,7 +14,9 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
 
-  double _maxValue = 50;
+  double _value = 50;
+  final double _minValue = -200;
+  final double _maxValue = 200;
 
   Widget myGauges() {
     return Scaffold(
@@ -147,10 +149,10 @@ class _MyAppState extends State<MyApp> {
               ],
             ),
             SegmentRadialGauge(
-              maxValue: 12,
-              actualValue: _maxValue,
+              maxValue: _maxValue,
+              actualValue: _value,
               // Optional Parameters
-              minValue: -4,
+              minValue: _minValue,
               size: 250,
               title: const Text('Zone Radial Gauge'),
               titlePosition: TitlePosition.top,
@@ -166,7 +168,7 @@ class _MyAppState extends State<MyApp> {
                   color: Colors.cyan,
                 ),
               ),
-              isPointer: true,
+              isPointer: false,
               titleText: "Title",
               title2Text: "Title2",
               segmentStartAngle: 135,
@@ -193,12 +195,12 @@ class _MyAppState extends State<MyApp> {
               ],
             ),
             Slider(
-              value: _maxValue,
-              min: -290,
-              max: 90,
+              value: _value,
+              min: _minValue + 10,
+              max: _maxValue - 10,
               onChanged: (value) {
                 setState(() {
-                  _maxValue = value;
+                  _value = value;
                 });
               },
             ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,28 +5,18 @@ void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({Key? key}) : super(key: key);
 
-  // This widget is the root of your application.
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      title: 'At Gauges',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
-      home: const MyGauges(),
-    );
-  }
+  State<MyApp> createState() => _MyAppState();
 }
 
-class MyGauges extends StatelessWidget {
-  const MyGauges({Key? key}) : super(key: key);
+class _MyAppState extends State<MyApp> {
 
-  @override
-  Widget build(BuildContext context) {
+  double _maxValue = 50;
+
+  Widget myGauges() {
     return Scaffold(
       // appBar: AppBar(title: const Text('Radial Gauges')),
       body: SafeArea(
@@ -52,7 +42,7 @@ class MyGauges extends StatelessWidget {
               maxValue: 100,
               actualValue: 70,
               // Optional Parameters
-              minValue: 0,
+              minValue: -0,
               size: 400,
               title: Text('Scale Radial Gauge'),
               titlePosition: TitlePosition.top,
@@ -87,12 +77,147 @@ class MyGauges extends StatelessWidget {
               majorTickStrokeWidth: 3,
               minorTickStrokeWidth: 3,
               actualValueTextStyle:
-                  const TextStyle(color: Colors.black, fontSize: 15),
+              const TextStyle(color: Colors.black, fontSize: 15),
               majorTickValueTextStyle: const TextStyle(color: Colors.black),
+            ),
+            const SegmentRadialGauge(
+              maxValue: -50,
+              actualValue: -120,
+              // Optional Parameters
+              minValue: -150,
+              size: 250,
+              title: Text('Zone Radial Gauge'),
+              titlePosition: TitlePosition.top,
+              pointerColor: Colors.cyan,
+              needleColor: Colors.cyan,
+              decimalPlaces: 2,
+              isAnimate: true,
+              animationDuration: 100,
+              unit: TextSpan(
+                text: 'V',
+                style: TextStyle(
+                  fontSize: 10,
+                  color: Colors.cyan,
+                ),
+              ),
+              isPointer: true,
+              titleText: "Title",
+              title2Text: "Title2",
+            ),
+            SegmentRadialGauge(
+              maxValue: 100,
+              actualValue: 50,
+              // Optional Parameters
+              minValue: 35,
+              size: 250,
+              title: const Text('Zone Radial Gauge'),
+              titlePosition: TitlePosition.top,
+              pointerColor: Colors.cyan,
+              needleColor: Colors.cyan,
+              decimalPlaces: 0,
+              isAnimate: true,
+              animationDuration: 100,
+              unit: const TextSpan(
+                text: 'V',
+                style: TextStyle(
+                  fontSize: 10,
+                  color: Colors.cyan,
+                ),
+              ),
+              isPointer: true,
+              titleText: "Title",
+              title2Text: "Title2",
+              segmentList: [
+                ZoneSegment(
+                  size: 1,
+                  color: Colors.red.withOpacity(0.95),
+                ),
+                ZoneSegment(
+                  size: 2,
+                  color: Colors.blue.withOpacity(0.95),
+                ),
+                ZoneSegment(
+                  size: 3,
+                  color: Colors.orangeAccent.withOpacity(0.95),
+                ),
+                ZoneSegment(
+                  size: 4,
+                  color: Colors.greenAccent.withOpacity(0.95),
+                ),
+              ],
+            ),
+            SegmentRadialGauge(
+              maxValue: 12,
+              actualValue: _maxValue,
+              // Optional Parameters
+              minValue: -4,
+              size: 250,
+              title: const Text('Zone Radial Gauge'),
+              titlePosition: TitlePosition.top,
+              pointerColor: Colors.cyan,
+              needleColor: Colors.cyan,
+              decimalPlaces: 2,
+              isAnimate: true,
+              animationDuration: 100,
+              unit: const TextSpan(
+                text: 'V',
+                style: TextStyle(
+                  fontSize: 10,
+                  color: Colors.cyan,
+                ),
+              ),
+              isPointer: true,
+              titleText: "Title",
+              title2Text: "Title2",
+              segmentStartAngle: 135,
+              segmentSweepAngle: 270,
+              segmentMainNo: 8,
+              segmentSubNo: 5,
+              segmentList: [
+                ZoneSegment(
+                  size: 1,
+                  color: Colors.red.withOpacity(0.95),
+                ),
+                ZoneSegment(
+                  size: 2,
+                  color: Colors.blue.withOpacity(0.95),
+                ),
+                ZoneSegment(
+                  size: 1,
+                  color: Colors.orangeAccent.withOpacity(0.95),
+                ),
+                ZoneSegment(
+                  size: 4,
+                  color: Colors.greenAccent.withOpacity(0.95),
+                ),
+              ],
+            ),
+            Slider(
+              value: _maxValue,
+              min: -290,
+              max: 90,
+              onChanged: (value) {
+                setState(() {
+                  _maxValue = value;
+                });
+              },
             ),
           ],
         ),
       ),
+    );
+  }
+
+  // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'At Gauges',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: myGauges(),
     );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,198 +14,273 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
 
-  double _value = 50;
-  final double _minValue = -200;
-  final double _maxValue = 200;
+  double _value = 20;
+  final double _minValue = 0;
+  final double _maxValue = 27;
 
   Widget myGauges() {
     return Scaffold(
       // appBar: AppBar(title: const Text('Radial Gauges')),
-      body: SafeArea(
-        child: GridView.count(
-          crossAxisCount: 2,
-          children: [
-            const SimpleRadialGauge(
-              actualValue: 50,
-              maxValue: 100,
-              // Optional Parameters
-              minValue: 0,
-              title: Text('Simple Radial Gauge'),
-              titlePosition: TitlePosition.top,
-              unit: 'L',
-              icon: Icon(Icons.water),
-              pointerColor: Colors.blue,
-              decimalPlaces: 0,
-              isAnimate: true,
-              animationDuration: 2000,
-              size: 400,
-            ),
-            const ScaleRadialGauge(
-              maxValue: 100,
-              actualValue: 70,
-              // Optional Parameters
-              minValue: -0,
-              size: 400,
-              title: Text('Scale Radial Gauge'),
-              titlePosition: TitlePosition.top,
-              pointerColor: Colors.blue,
-              needleColor: Colors.blue,
-              decimalPlaces: 0,
-              isAnimate: true,
-              animationDuration: 2000,
-              unit: TextSpan(text: 'Km/h', style: TextStyle(fontSize: 10)),
-            ),
-            SimpleLinearGauge(
-              maxValue: 100,
-              actualValue: 76,
-              //Optional Parameters
-              minValue: 0,
-              divisions: 10,
+      body: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return SingleChildScrollView(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  const SimpleRadialGauge(
+                    actualValue: 50,
+                    maxValue: 100,
+                    // Optional Parameters
+                    minValue: 0,
+                    title: Text('Simple Radial Gauge'),
+                    titlePosition: TitlePosition.top,
+                    unit: 'L',
+                    icon: Icon(Icons.water),
+                    pointerColor: Colors.blue,
+                    decimalPlaces: 0,
+                    isAnimate: true,
+                    animationDuration: 2000,
+                    size: 400,
+                  ),
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  const ScaleRadialGauge(
+                    maxValue: 100,
+                    actualValue: 70,
+                    // Optional Parameters
+                    minValue: 0,
+                    size: 400,
+                    title: Text('Scale Radial Gauge'),
+                    titlePosition: TitlePosition.top,
+                    pointerColor: Colors.blue,
+                    needleColor: Colors.blue,
+                    decimalPlaces: 0,
+                    isAnimate: true,
+                    animationDuration: 2000,
+                    unit: TextSpan(text: 'Km/h', style: TextStyle(fontSize: 10)),
+                  ),
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  SimpleLinearGauge(
+                    // size: 600,
+                    maxValue: 100,
+                    actualValue: 80,
+                    //Optional Parameters
+                    minValue: -50,
+                    divisions: 10,
 
-              title: const Text('Simple Linear Gauge'),
-              titlePosition: TitlePosition.top,
-              pointerColor: Colors.blue,
-              pointerIcon: const Icon(
-                Icons.water_drop,
-                color: Colors.blue,
-                // size: 40,
+                    title: const Text('Simple Linear Gauge'),
+                    titlePosition: TitlePosition.top,
+                    pointerColor: Colors.blue,
+                    pointerIcon: const Icon(
+                      // Icons.water_drop,
+                      Icons.arrow_forward,
+                      color: Colors.blue,
+                      size: 20,
+                    ),
+                    decimalPlaces: 0,
+                    isAnimate: true,
+                    animationDuration: 2000,
+                    gaugeOrientation: GaugeOrientation.vertical,
+                    gaugeStrokeWidth: 3,
+                    rangeStrokeWidth: 3,
+                    majorTickStrokeWidth: 2,
+                    minorTickStrokeWidth: 1,
+                    actualValueTextStyle:
+                      const TextStyle(color: Colors.black, fontSize: 12),
+                    majorTickValueTextStyle: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 10,
+                    ),
+                    unitString: '\u2103',
+                  ),
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  SimpleLinearGauge(
+                    maxValue: 100,
+                    actualValue: 80,
+                    //Optional Parameters
+                    minValue: -40,
+                    divisions: 7,
+                    title: const Text('Simple Linear Gauge'),
+                    titlePosition: TitlePosition.bottom,
+                    pointerColor: Colors.blue,
+                    pointerIcon: const Icon(
+                      Icons.arrow_downward,
+                      // Icons.water_drop,
+                      color: Colors.blue,
+                      size: 15,
+                    ),
+                    decimalPlaces: 1,
+                    isAnimate: true,
+                    animationDuration: 125,
+                    gaugeOrientation: GaugeOrientation.horizontal,
+                    gaugeStrokeWidth: 10,
+                    rangeStrokeWidth: 10,
+                    majorTickStrokeWidth: 2,
+                    minorTickStrokeWidth: 1,
+                    actualValueTextStyle:
+                    const TextStyle(color: Colors.black, fontSize: 12),
+                    majorTickValueTextStyle: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 10,
+                    ),
+                    majorTicksDecimalPlace: 0,
+                    unitString: '\u2103',
+                    size: 400,
+                  ),
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  const SegmentRadialGauge(
+                    maxValue: -50,
+                    actualValue: -120,
+                    // Optional Parameters
+                    minValue: -150,
+                    size: 250,
+                    title: Text('Zone Radial Gauge'),
+                    titlePosition: TitlePosition.top,
+                    pointerColor: Colors.cyan,
+                    needleColor: Colors.cyan,
+                    decimalPlaces: 2,
+                    isAnimate: true,
+                    animationDuration: 100,
+                    unit: TextSpan(
+                      text: 'V',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Colors.cyan,
+                      ),
+                    ),
+                    isPointer: true,
+                    titleText: "Title",
+                    title2Text: "Title2",
+                  ),
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  SegmentRadialGauge(
+                    maxValue: 100,
+                    actualValue: 50,
+                    // Optional Parameters
+                    minValue: 35,
+                    size: 250,
+                    title: const Text('Zone Radial Gauge'),
+                    titlePosition: TitlePosition.top,
+                    pointerColor: Colors.cyan,
+                    needleColor: Colors.cyan,
+                    decimalPlaces: 0,
+                    isAnimate: true,
+                    animationDuration: 100,
+                    unit: const TextSpan(
+                      text: 'V',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Colors.cyan,
+                      ),
+                    ),
+                    isPointer: true,
+                    titleText: "Title",
+                    title2Text: "Title2",
+                    segmentList: [
+                      ZoneSegment(
+                        size: 1,
+                        color: Colors.red.withOpacity(0.95),
+                      ),
+                      ZoneSegment(
+                        size: 2,
+                        color: Colors.blue.withOpacity(0.95),
+                      ),
+                      ZoneSegment(
+                        size: 3,
+                        color: Colors.orangeAccent.withOpacity(0.95),
+                      ),
+                      ZoneSegment(
+                        size: 4,
+                        color: Colors.greenAccent.withOpacity(0.95),
+                      ),
+                    ],
+                  ),
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  SegmentRadialGauge(
+                    maxValue: _maxValue,
+                    actualValue: _value,
+                    // Optional Parameters
+                    minValue: _minValue,
+                    size: 250,
+                    title: const Text('Zone Radial Gauge'),
+                    titlePosition: TitlePosition.top,
+                    pointerColor: Colors.cyan,
+                    needleColor: Colors.cyan,
+                    decimalPlaces: 2,
+                    isAnimate: true,
+                    animationDuration: 125,
+                    unit: const TextSpan(
+                      text: 'V',
+                      style: TextStyle(
+                        fontSize: 10,
+                        color: Colors.cyan,
+                      ),
+                    ),
+                    isPointer: false,
+                    titleText: "Title",
+                    title2Text: "Title2",
+                    segmentStartAngle: 135,
+                    segmentSweepAngle: 270,
+                    segmentMainNo: 8,
+                    segmentSubNo: 5,
+                    segmentList: [
+                      ZoneSegment(
+                        size: 1,
+                        color: Colors.red.withOpacity(0.95),
+                      ),
+                      ZoneSegment(
+                        size: 2,
+                        color: Colors.blue.withOpacity(0.95),
+                      ),
+                      ZoneSegment(
+                        size: 1,
+                        color: Colors.orangeAccent.withOpacity(0.95),
+                      ),
+                      ZoneSegment(
+                        size: 4,
+                        color: Colors.greenAccent.withOpacity(0.95),
+                      ),
+                    ],
+                  ),
+                  const Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: SizedBox.shrink()
+                  ),
+                  Slider(
+                    value: _value,
+                    min: _minValue + 1,
+                    max: _maxValue - 1,
+                    onChanged: (value) {
+                      setState(() {
+                        _value = value;
+                      });
+                    },
+                  ),
+                ],
               ),
-              decimalPlaces: 0,
-              isAnimate: true,
-              animationDuration: 2000,
-              gaugeOrientation: GaugeOrientation.vertical,
-              gaugeStrokeWidth: 5,
-              rangeStrokeWidth: 5,
-              majorTickStrokeWidth: 3,
-              minorTickStrokeWidth: 3,
-              actualValueTextStyle:
-              const TextStyle(color: Colors.black, fontSize: 15),
-              majorTickValueTextStyle: const TextStyle(color: Colors.black),
-            ),
-            const SegmentRadialGauge(
-              maxValue: -50,
-              actualValue: -120,
-              // Optional Parameters
-              minValue: -150,
-              size: 250,
-              title: Text('Zone Radial Gauge'),
-              titlePosition: TitlePosition.top,
-              pointerColor: Colors.cyan,
-              needleColor: Colors.cyan,
-              decimalPlaces: 2,
-              isAnimate: true,
-              animationDuration: 100,
-              unit: TextSpan(
-                text: 'V',
-                style: TextStyle(
-                  fontSize: 10,
-                  color: Colors.cyan,
-                ),
-              ),
-              isPointer: true,
-              titleText: "Title",
-              title2Text: "Title2",
-            ),
-            SegmentRadialGauge(
-              maxValue: 100,
-              actualValue: 50,
-              // Optional Parameters
-              minValue: 35,
-              size: 250,
-              title: const Text('Zone Radial Gauge'),
-              titlePosition: TitlePosition.top,
-              pointerColor: Colors.cyan,
-              needleColor: Colors.cyan,
-              decimalPlaces: 0,
-              isAnimate: true,
-              animationDuration: 100,
-              unit: const TextSpan(
-                text: 'V',
-                style: TextStyle(
-                  fontSize: 10,
-                  color: Colors.cyan,
-                ),
-              ),
-              isPointer: true,
-              titleText: "Title",
-              title2Text: "Title2",
-              segmentList: [
-                ZoneSegment(
-                  size: 1,
-                  color: Colors.red.withOpacity(0.95),
-                ),
-                ZoneSegment(
-                  size: 2,
-                  color: Colors.blue.withOpacity(0.95),
-                ),
-                ZoneSegment(
-                  size: 3,
-                  color: Colors.orangeAccent.withOpacity(0.95),
-                ),
-                ZoneSegment(
-                  size: 4,
-                  color: Colors.greenAccent.withOpacity(0.95),
-                ),
-              ],
-            ),
-            SegmentRadialGauge(
-              maxValue: _maxValue,
-              actualValue: _value,
-              // Optional Parameters
-              minValue: _minValue,
-              size: 250,
-              title: const Text('Zone Radial Gauge'),
-              titlePosition: TitlePosition.top,
-              pointerColor: Colors.cyan,
-              needleColor: Colors.cyan,
-              decimalPlaces: 2,
-              isAnimate: true,
-              animationDuration: 100,
-              unit: const TextSpan(
-                text: 'V',
-                style: TextStyle(
-                  fontSize: 10,
-                  color: Colors.cyan,
-                ),
-              ),
-              isPointer: false,
-              titleText: "Title",
-              title2Text: "Title2",
-              segmentStartAngle: 135,
-              segmentSweepAngle: 270,
-              segmentMainNo: 8,
-              segmentSubNo: 5,
-              segmentList: [
-                ZoneSegment(
-                  size: 1,
-                  color: Colors.red.withOpacity(0.95),
-                ),
-                ZoneSegment(
-                  size: 2,
-                  color: Colors.blue.withOpacity(0.95),
-                ),
-                ZoneSegment(
-                  size: 1,
-                  color: Colors.orangeAccent.withOpacity(0.95),
-                ),
-                ZoneSegment(
-                  size: 4,
-                  color: Colors.greenAccent.withOpacity(0.95),
-                ),
-              ],
-            ),
-            Slider(
-              value: _value,
-              min: _minValue + 10,
-              max: _maxValue - 10,
-              onChanged: (value) {
-                setState(() {
-                  _value = value;
-                });
-              },
-            ),
-          ],
-        ),
+            );
+          }
       ),
     );
   }

--- a/lib/at_gauges.dart
+++ b/lib/at_gauges.dart
@@ -4,6 +4,7 @@ library at_gauges;
 export 'src/linear_gauges/linear_gauge.dart';
 export 'src/radial_gauges/scale_radial_gauge.dart';
 export 'src/radial_gauges/simple_radial_gauge.dart';
+export 'src/radial_gauges/segment_radial_gauge.dart';
 export 'src/utils/enums.dart';
 export 'src/utils/range.dart';
 export 'src/utils/utils.dart';

--- a/lib/src/linear_gauges/simple_linear_gauge.dart
+++ b/lib/src/linear_gauges/simple_linear_gauge.dart
@@ -22,10 +22,13 @@ class SimpleLinearGauge extends LinearCustomGauge {
     GaugeOrientation gaugeOrientation = GaugeOrientation.vertical,
     double gaugeStrokeWidth = 5.0,
     double rangeStrokeWidth = 5.0,
-    double majorTickStrokeWidth = 5,
+    double majorTickStrokeWidth = 5.0,
     double minorTickStrokeWidth = 5.0,
     TextStyle actualValueTextStyle = const TextStyle(color: Colors.black),
     TextStyle majorTickValueTextStyle = const TextStyle(color: Colors.black),
+    int majorTicksDecimalPlace = 0,
+    String unitString = "",
+    double size = 400,
   })  : assert(rangeStrokeWidth <= gaugeStrokeWidth,
             'rangeStrokeWidth must not be greater than gaugeStrokeWidth'),
         super(
@@ -39,7 +42,7 @@ class SimpleLinearGauge extends LinearCustomGauge {
           pointerIcon: pointerIcon,
           decimalPlaces: decimalPlaces,
           isAnimate: isAnimate,
-          milliseconds: animationDuration,
+          animationDuration: animationDuration,
           gaugeStrokeWidth: gaugeStrokeWidth,
           rangeStrokeWidth: rangeStrokeWidth,
           majorTickStrokeWidth: majorTickStrokeWidth,
@@ -47,6 +50,9 @@ class SimpleLinearGauge extends LinearCustomGauge {
           actualValueTextStyle: actualValueTextStyle,
           majorTicksValueTextStyle: majorTickValueTextStyle,
           gaugeOrientation: gaugeOrientation,
+          majorTicksDecimalPlace: majorTicksDecimalPlace,
+          unitString: unitString,
+          size: size,
         );
 
   @override
@@ -64,9 +70,11 @@ class _SimpleLinearGaugeState extends State<SimpleLinearGauge>
 
     animationController = AnimationController(
         duration: RadialHelper.getDuration(
-            isAnimate: widget.isAnimate, userMilliseconds: widget.milliseconds),
+            isAnimate: widget.isAnimate, userMilliseconds: widget.animationDuration),
         vsync: this,
-        upperBound: widget.maxValue);
+        upperBound: widget.maxValue,
+        lowerBound: widget.minValue,
+    );
 
     animation = Tween<double>().animate(animationController)
       ..addListener(() {
@@ -88,27 +96,79 @@ class _SimpleLinearGaugeState extends State<SimpleLinearGauge>
   @override
   Widget build(BuildContext context) {
     if (animationController.value != widget.actualValue) {
-      animationController.animateTo(widget.actualValue);
+      animationController.animateTo(
+        widget.actualValue,
+        duration: RadialHelper.getDuration(
+          isAnimate: widget.isAnimate,
+          userMilliseconds: widget.animationDuration
+        ),
+      );
     }
-    return CustomPaint(
-      child: SizedBox.expand(),
-      painter: SimpleLinearGaugePainter(
-        maxValue: widget.maxValue,
-        minValue: widget.minValue,
-        actualValue: animationController.value,
-        divisions: widget.divisions,
-        title: widget.title,
-        titlePosition: widget.titlePosition,
-        pointerColor: widget.pointerColor,
-        pointerIcon: widget.pointerIcon,
-        decimalPlaces: widget.decimalPlaces,
-        rangeStrokeWidth: widget.rangeStrokeWidth,
-        gaugeStrokeWidth: widget.gaugeStrokeWidth,
-        majorTickStrokeWidth: widget.majorTickStrokeWidth,
-        minorTickStrokeWidth: widget.minorTickStrokeWidth,
-        actualValueTextStyle: widget.actualValueTextStyle,
-        majorTicksValueTextStyle: widget.majorTicksValueTextStyle,
-        gaugeOrientation: widget.gaugeOrientation,
+    // return CustomPaint(
+    //   child: SizedBox.expand(),
+    //   painter: SimpleLinearGaugePainter(
+    //     maxValue: widget.maxValue,
+    //     minValue: widget.minValue,
+    //     actualValue: animationController.value,
+    //     divisions: widget.divisions,
+    //     title: widget.title,
+    //     titlePosition: widget.titlePosition,
+    //     pointerColor: widget.pointerColor,
+    //     pointerIcon: widget.pointerIcon,
+    //     decimalPlaces: widget.decimalPlaces,
+    //     rangeStrokeWidth: widget.rangeStrokeWidth,
+    //     gaugeStrokeWidth: widget.gaugeStrokeWidth,
+    //     majorTickStrokeWidth: widget.majorTickStrokeWidth,
+    //     minorTickStrokeWidth: widget.minorTickStrokeWidth,
+    //     actualValueTextStyle: widget.actualValueTextStyle,
+    //     majorTicksValueTextStyle: widget.majorTicksValueTextStyle,
+    //     gaugeOrientation: widget.gaugeOrientation,
+    //     unitString: widget.unitString,
+    //   ),
+    // );
+    return SizedBox(
+      width: (widget.gaugeOrientation == GaugeOrientation.horizontal) ? widget.size : widget.size / 2,
+      height: (widget.gaugeOrientation == GaugeOrientation.horizontal) ? widget.size / 2 : widget.size,
+      child: FittedBox(
+        child: Column(
+          children: [
+            Container(
+              // decoration: BoxDecoration(
+              //     border: Border.all(color: Colors.blueAccent)
+              // ),
+              width: (widget.gaugeOrientation == GaugeOrientation.horizontal) ? 400 : 200,
+              height: (widget.gaugeOrientation == GaugeOrientation.horizontal) ? 200 : 400,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: CustomPaint(
+                  painter: SimpleLinearGaugePainter(
+                    maxValue: widget.maxValue,
+                    minValue: widget.minValue,
+                    actualValue: animationController.value,
+                    divisions: widget.divisions,
+                    title: widget.title,
+                    titlePosition: widget.titlePosition,
+                    pointerColor: widget.pointerColor,
+                    pointerIcon: widget.pointerIcon,
+                    decimalPlaces: widget.decimalPlaces,
+                    rangeStrokeWidth: widget.rangeStrokeWidth,
+                    gaugeStrokeWidth: widget.gaugeStrokeWidth,
+                    majorTickStrokeWidth: widget.majorTickStrokeWidth,
+                    minorTickStrokeWidth: widget.minorTickStrokeWidth,
+                    actualValueTextStyle: widget.actualValueTextStyle,
+                    majorTicksValueTextStyle: widget.majorTicksValueTextStyle,
+                    gaugeOrientation: widget.gaugeOrientation,
+                    majorTicksDecimalPlace: widget.majorTicksDecimalPlace,
+                    unitString: widget.unitString,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/painters/linear/simple_linear_gauge_painter.dart
+++ b/lib/src/painters/linear/simple_linear_gauge_painter.dart
@@ -19,6 +19,8 @@ class SimpleLinearGaugePainter extends LinearCustomPainter {
     required double minorTickStrokeWidth,
     required TextStyle actualValueTextStyle,
     required TextStyle majorTicksValueTextStyle,
+    required int majorTicksDecimalPlace,
+    required String unitString,
   }) : super(
           minValue: minValue,
           maxValue: maxValue,
@@ -36,6 +38,8 @@ class SimpleLinearGaugePainter extends LinearCustomPainter {
           actualValueTextStyle: actualValueTextStyle,
           majorTicksValueTextStyle: majorTicksValueTextStyle,
           gaugeOrientation: gaugeOrientation,
+          majorTicksDecimalPlace: majorTicksDecimalPlace,
+          unitString: unitString,
         );
 
   @override

--- a/lib/src/painters/radial/scale_radial_gauge_painter.dart
+++ b/lib/src/painters/radial/scale_radial_gauge_painter.dart
@@ -147,10 +147,10 @@ class ScaleRadialGaugePainter extends CustomPainter {
           style: const TextStyle(color: Colors.black),
           children: [TextSpan(text: unit.text == '' ? '' : ' '), unit],
           text: RadialHelper.sweepAngleRadianToActualValue(
-                sweepAngle: sweepAngle,
-                maxValue: maxValue,
-                minValue: minValue,
-                maxDegrees: 300)
+                  sweepAngle: sweepAngle,
+                  maxValue: maxValue,
+                  minValue: minValue,
+                  maxDegrees: 300)
               .toStringAsFixed(decimalPlaces),
         ),
         textDirection: TextDirection.ltr)

--- a/lib/src/painters/radial/scale_radial_gauge_painter.dart
+++ b/lib/src/painters/radial/scale_radial_gauge_painter.dart
@@ -27,9 +27,9 @@ class ScaleRadialGaugePainter extends CustomPainter {
 
   List<double> getScale(double divider) {
     List<double> scale = [];
-    final double interval = maxValue / (divider - 1);
+    final double interval = (maxValue - minValue) / (divider - 1);
     for (double i = 0; i < divider; i++) {
-      scale.add((i * interval));
+      scale.add((minValue + i * interval));
     }
     scale.removeWhere((element) => element < minValue);
 
@@ -147,10 +147,10 @@ class ScaleRadialGaugePainter extends CustomPainter {
           style: const TextStyle(color: Colors.black),
           children: [TextSpan(text: unit.text == '' ? '' : ' '), unit],
           text: RadialHelper.sweepAngleRadianToActualValue(
-                  sweepAngle: sweepAngle,
-                  maxValue: maxValue,
-                  minValue: minValue,
-                  maxDegrees: 300)
+              sweepAngle: sweepAngle,
+              maxValue: maxValue,
+              minValue: minValue,
+              maxDegrees: 300)
               .toStringAsFixed(decimalPlaces),
         ),
         textDirection: TextDirection.ltr)

--- a/lib/src/painters/radial/scale_radial_gauge_painter.dart
+++ b/lib/src/painters/radial/scale_radial_gauge_painter.dart
@@ -147,10 +147,10 @@ class ScaleRadialGaugePainter extends CustomPainter {
           style: const TextStyle(color: Colors.black),
           children: [TextSpan(text: unit.text == '' ? '' : ' '), unit],
           text: RadialHelper.sweepAngleRadianToActualValue(
-              sweepAngle: sweepAngle,
-              maxValue: maxValue,
-              minValue: minValue,
-              maxDegrees: 300)
+                sweepAngle: sweepAngle,
+                maxValue: maxValue,
+                minValue: minValue,
+                maxDegrees: 300)
               .toStringAsFixed(decimalPlaces),
         ),
         textDirection: TextDirection.ltr)

--- a/lib/src/painters/radial/segment_radial_gauge_painter.dart
+++ b/lib/src/painters/radial/segment_radial_gauge_painter.dart
@@ -1,0 +1,428 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+import '../../utils/utils.dart';
+
+class SegmentRadialGaugePainter extends CustomPainter {
+  SegmentRadialGaugePainter({
+    required this.sweepAngle,
+    required this.pointerColor,
+    required this.minValue,
+    required this.maxValue,
+    required this.actualValue,
+    required this.needleColor,
+    required this.decimalPlaces,
+    required this.unit,
+    required this.isPointer,
+    required this.titleText,
+    required this.title2Text,
+    required this.segmentStartAngle,
+    required this.segmentSweepAngle,
+    required this.segmentMainNo,
+    required this.segmentSubNo,
+    required this.segmentList,
+    Key? key,
+  });
+  final double sweepAngle;
+  final Color pointerColor;
+  final double minValue;
+  final double maxValue;
+  final double actualValue;
+  final Color needleColor;
+  final int decimalPlaces;
+  final TextSpan unit;
+
+  final bool isPointer;
+  final String titleText;
+  final String title2Text;
+  final double segmentStartAngle;
+  final double segmentSweepAngle;
+  final int segmentMainNo;
+  final int segmentSubNo;
+  final List<ZoneSegment> segmentList;
+
+  List<double> getScale(double divider) {
+    List<double> scale = [];
+    final double interval = (maxValue - minValue) / (divider - 1);
+    for (double i = 0; i < divider; i++) {
+      scale.add((minValue + i * interval));
+    }
+    scale.removeWhere((element) => element < minValue);
+    return scale;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final startAngle = RadialHelper.degreesToRadians(segmentStartAngle);
+    final backgroundSweepAngle = RadialHelper.degreesToRadians(segmentSweepAngle);
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = size.width * 1 / 2;
+    var arcRect = Rect.fromCircle(center: center, radius: radius);
+
+    final zoneRadius = size.width * 1 / 2 - 16.5;
+    var zoneArcRect = Rect.fromCircle(center: center, radius: zoneRadius);
+
+    if (segmentList.isNotEmpty) {
+      double totalSegmentSize = 0;
+      for (var segment in segmentList) {
+        totalSegmentSize = totalSegmentSize + segment.size;
+      }
+
+      int segmentListLength = segmentList.length;
+      for (int i = 0; i < segmentListLength; i++) {
+        var segmentSize = segmentList[i].size;
+        var segmentColor = segmentList[i].color;
+
+        // Draw Zone Arc
+        double previousSegmentAngleSum = 0;
+
+        if (i != 0) {
+          for (int j = 0; j < i; j++) {
+            previousSegmentAngleSum = previousSegmentAngleSum + segmentList[j].size;
+          }
+        }
+
+        final zoneStartAngle = RadialHelper.degreesToRadians(
+            segmentStartAngle +
+            segmentSweepAngle / totalSegmentSize * previousSegmentAngleSum
+        );
+
+        final zoneSweepAngle = RadialHelper.degreesToRadians(
+            segmentSweepAngle / totalSegmentSize * segmentSize
+        );
+
+        final zoneArcPaint = Paint()
+          ..color = segmentColor
+          ..strokeWidth = 17.5
+          ..style = PaintingStyle.stroke;
+
+        canvas.drawArc(
+            zoneArcRect, zoneStartAngle, zoneSweepAngle, false, zoneArcPaint);
+      }
+    }
+
+    // use scale radial gauge pointer style or segment gauge style
+    if (isPointer) {
+      // Background Arc
+      final backgroundArcPaint = Paint()
+        ..color = Colors.black12
+        ..strokeWidth = 5
+        ..style = PaintingStyle.stroke;
+
+      canvas.drawArc(
+          arcRect, startAngle, backgroundSweepAngle, false, backgroundArcPaint);
+
+      // Arc Pointer
+      var pointerArcPaint = Paint()
+        ..color = pointerColor
+        ..strokeWidth = 10
+        ..strokeCap = StrokeCap.butt
+        ..style = PaintingStyle.stroke;
+
+      canvas.drawArc(arcRect, startAngle, sweepAngle, false, pointerArcPaint);
+
+    } else {
+      // Background Circle
+      final backgroundCirclePaint = Paint()
+        ..color = Colors.black12
+        ..strokeWidth = 10
+        ..style = PaintingStyle.stroke;
+
+      canvas.drawCircle(
+          center, radius, backgroundCirclePaint);
+
+      // Background Outer Circle
+      final outerRadius = size.width * 1 / 2 + 5;
+
+      final backgroundOuterCirclePaint = Paint()
+        ..color = Colors.black26
+        ..strokeWidth = 1
+        ..style = PaintingStyle.stroke;
+
+      canvas.drawCircle(
+          center, outerRadius, backgroundOuterCirclePaint);
+    }
+
+    // Arc Needle
+    var needlePaint = Paint()
+      ..color = needleColor
+      ..strokeWidth = 5
+      ..style = PaintingStyle.fill;
+
+    var needleEndPointOffset = Offset(
+      (center.dx) + (radius - 15) * cos(pi / 1.5 + sweepAngle),
+      (center.dx) + (radius - 15) * sin(pi / 1.5 + sweepAngle),
+    );
+
+    canvas.drawLine(center, needleEndPointOffset, needlePaint);
+    canvas.drawCircle(center, 5, needlePaint);
+
+    final halfOfMinMaxValue = (minValue + maxValue) / 2;
+    final zeroTextGapMin    = halfOfMinMaxValue / (maxValue - minValue);
+    final zeroTextGapHalf   = minValue / (maxValue - minValue);
+    final zeroTextGapMax    = maxValue / (maxValue - minValue);
+
+    // Print min / half / max Value Text
+    List<double> valueTextList = [minValue, halfOfMinMaxValue, maxValue, 0];
+    double valueFontSizeOffset = 0;
+
+    for (var value in valueTextList) {
+      var valueLength = value.toStringAsFixed(decimalPlaces).length;
+      double valueFontSizeOffsetT = (valueLength / 3).ceil().toDouble();
+      if (valueFontSizeOffset < valueFontSizeOffsetT) {
+        if (valueFontSizeOffsetT > 2) {
+          valueFontSizeOffset = 1.2 * valueFontSizeOffsetT.ceil().toDouble();
+        } else {
+          valueFontSizeOffset = valueFontSizeOffsetT;
+        }
+      }
+    }
+
+    for (var value in valueTextList) {
+      var valueLength = value.toStringAsFixed(decimalPlaces).length;
+      bool needValueOffset = false;
+      double valueRnd = double.tryParse(value.toStringAsFixed(0)) ?? 0;
+      double maxValueOffset = 7.5;
+      if (valueRnd != value) {
+        needValueOffset = true;
+        maxValueOffset = 10;
+      } else {
+        valueLength = value.toStringAsFixed(0).length;
+      }
+
+      final TextPainter valueTextPainter = TextPainter(
+        text: TextSpan(
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 12 - valueFontSizeOffset,
+          ),
+          text: !needValueOffset ? value.toStringAsFixed(0)
+              : value.toStringAsFixed(decimalPlaces),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+
+      // get sweep angle for every value
+      var scaleSweepAngle = RadialHelper.actualValueToSweepAngleRadian(
+          actualValue: value,
+          maxValue: maxValue,
+          maxDegrees: segmentSweepAngle,
+          minValue: minValue);
+
+      if (value == minValue) {
+        var minValueScaleOffset = Offset(
+            (center.dx) +
+                // (radius - scaleSweepAngle - (45 - valueLength * 3)) *
+                (radius - scaleSweepAngle - (35 - valueLength * 3)) *
+                    cos(startAngle + scaleSweepAngle),
+            (center.dy) +
+                (radius - scaleSweepAngle - 45) *
+                    sin(startAngle + scaleSweepAngle)
+        );
+
+        valueTextPainter.paint(canvas, minValueScaleOffset);
+      } else if (value == halfOfMinMaxValue) {
+        var halfValueScaleOffset = Offset(
+            (center.dx - ((value != 0) ? valueLength : 0) *
+                ((valueLength != 3) ? (valueLength / 5).ceil() : 2.5) - 2),
+            (center.dy) +
+                (radius - scaleSweepAngle - 30) *
+                    sin(startAngle + scaleSweepAngle)
+        );
+
+        valueTextPainter.paint(canvas, halfValueScaleOffset);
+      } else if (value == maxValue) {
+        var maxValueScaleOffset = Offset(0, 0);
+        if (valueLength >= 5) {
+          maxValueScaleOffset = Offset(
+              (center.dx) +
+                  (radius - scaleSweepAngle -
+                      (maxValueOffset + valueLength * 10)) *
+                      cos(startAngle + scaleSweepAngle),
+              (center.dy) +
+                  (radius - scaleSweepAngle - 39.75) *
+                      sin(startAngle + scaleSweepAngle));
+        } else {
+          maxValueScaleOffset = Offset(
+              (center.dx) +
+                  (radius - scaleSweepAngle -
+                      ((maxValueOffset + valueLength) * 5)) *
+                      cos(startAngle + scaleSweepAngle),
+              (center.dy) +
+                  (radius - scaleSweepAngle - 39.75) *
+                      sin(startAngle + scaleSweepAngle));
+        }
+
+        valueTextPainter.paint(canvas, maxValueScaleOffset);
+      } else if (value == 0 && (minValue < 0) && (0 < maxValue)) {
+        // Draw 0 if minValue is not 0
+        if (
+               (zeroTextGapMin.abs()  > 0.08)
+            && (zeroTextGapHalf.abs() > 0.08)
+            && (zeroTextGapMax.abs()  > 0.08)
+        ) {
+          var scaleOffset = Offset(0, 0);
+          if (value < halfOfMinMaxValue) {
+            scaleOffset = Offset(
+                (center.dx) +
+                    (radius - scaleSweepAngle - 35) *
+                        cos(startAngle + scaleSweepAngle),
+                (center.dy) +
+                    (radius - scaleSweepAngle - 30) *
+                        sin(startAngle + scaleSweepAngle));
+          } else {
+            scaleOffset = Offset(
+                (center.dx) +
+                    (radius - scaleSweepAngle - 35) *
+                        cos(startAngle + scaleSweepAngle),
+                (center.dy) +
+                    (radius - scaleSweepAngle - 30) *
+                        sin(startAngle + scaleSweepAngle));
+          }
+
+          valueTextPainter.paint(canvas, scaleOffset);
+        }
+      }
+    }
+
+
+    final double totalSplitterNo = segmentSubNo * segmentMainNo + 1;
+    final valueList = getScale(totalSplitterNo);
+    for (int i = 0; i < valueList.length; i++) {
+      // get sweep angle for every value
+      var scaleSweepAngle = RadialHelper.actualValueToSweepAngleRadian(
+          actualValue: valueList[i],
+          maxValue: maxValue,
+          maxDegrees: segmentSweepAngle,
+          minValue: minValue);
+
+      // Main Segment Pointer Line
+      double pointerLineRadius1 = size.width * 1 / 2 - 8;
+      double pointerLineRadius2 = size.width * 1 / 3 + 7.5;
+
+      var pointerLineOffset1 = Offset(
+        (center.dx) + pointerLineRadius1 *
+            cos(startAngle + scaleSweepAngle + 0),
+        (center.dy) + pointerLineRadius1 *
+            sin(startAngle + scaleSweepAngle + 0),
+      );
+
+      var pointerLineOffset2 = Offset(
+        (center.dx) + pointerLineRadius2 *
+            cos(startAngle + scaleSweepAngle + 0),
+        (center.dy) + pointerLineRadius2 *
+            sin(startAngle + scaleSweepAngle + 0),
+      );
+
+      var pointerLinePaint = Paint()
+        ..color = Colors.black
+        ..strokeWidth = 1
+        ..style = PaintingStyle.fill;
+
+      // the main segment number should be multiply of sub segment number
+      if ((i % segmentSubNo) == 0) {
+        if (isPointer) {
+          var strokeCapCirclePaint = Paint()
+            ..color = Colors.white
+            ..strokeWidth = 5
+            ..style = PaintingStyle.fill;
+
+          var strokeCapCircleOffset = Offset(
+            (center.dx) + radius * cos(startAngle + scaleSweepAngle + 0),
+            (center.dy) + radius * sin(startAngle + scaleSweepAngle + 0),
+          );
+
+          var strokeCapCircleRadius = 3.0;
+
+          canvas.drawCircle(
+              strokeCapCircleOffset, strokeCapCircleRadius, strokeCapCirclePaint);
+        }
+
+      } else {
+        // Sub Segment Pointer Line Adjustment
+        pointerLineRadius2 = size.width * 1 / 3 + 12.5;
+
+        pointerLinePaint = Paint()
+          ..color = Colors.black
+          ..strokeWidth = 0.5
+          ..style = PaintingStyle.fill;
+      }
+
+      canvas.drawLine(
+          pointerLineOffset1, pointerLineOffset2, pointerLinePaint);
+    }
+
+    final TextPainter actualValueTextPainter = TextPainter(
+        text: TextSpan(
+          style: const TextStyle(color: Colors.black),
+          children: [TextSpan(text: unit.text == '' ? '' : ' '), unit],
+          text: RadialHelper.sweepAngleRadianToActualValue(
+              sweepAngle: sweepAngle,
+              maxValue: maxValue,
+              minValue: minValue,
+              maxDegrees: segmentSweepAngle,
+          ).toStringAsFixed(decimalPlaces),
+        ),
+        textDirection: TextDirection.ltr)
+      ..layout();
+
+    final actualValueOffset = Offset(
+        size.width / 2 - (actualValueTextPainter.width / 2),
+        size.height / 1.75
+    );
+
+    actualValueTextPainter.paint(canvas, actualValueOffset);
+
+    double titleFont = 11;
+    if (titleText.length > 10) {
+      titleFont = titleText.length.toDouble() / 2;
+    }
+
+    final TextPainter titleTextPainter = TextPainter(
+        text: TextSpan(
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: titleFont,
+          ),
+          text: titleText,
+        ),
+        textDirection: TextDirection.ltr)
+      ..layout();
+
+    final titleOffset = Offset(
+        size.width / 2 - (titleTextPainter.width / 2),
+        size.height / 1.2
+    );
+
+    titleTextPainter.paint(canvas, titleOffset);
+
+    double title2Font = 18;
+    if (title2Text.length > 10) {
+      title2Font = title2Text.length.toDouble() / 2;
+    }
+
+    final TextPainter title2TextPainter = TextPainter(
+        text: TextSpan(
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: title2Font,
+          ),
+          text: title2Text,
+        ),
+        textDirection: TextDirection.ltr)
+      ..layout();
+
+    final title2Offset = Offset(
+        size.width / 2 - (title2TextPainter.width / 2),
+        size.height / 3.5
+    );
+
+    title2TextPainter.paint(canvas, title2Offset);
+  }
+
+  @override
+  bool shouldRepaint(SegmentRadialGaugePainter oldDelegate) {
+    return true;
+  }
+}

--- a/lib/src/painters/radial/segment_radial_gauge_painter.dart
+++ b/lib/src/painters/radial/segment_radial_gauge_painter.dart
@@ -151,8 +151,8 @@ class SegmentRadialGaugePainter extends CustomPainter {
       ..style = PaintingStyle.fill;
 
     var needleEndPointOffset = Offset(
-      (center.dx) + (radius - 15) * cos(pi / 1.5 + sweepAngle),
-      (center.dx) + (radius - 15) * sin(pi / 1.5 + sweepAngle),
+      (center.dx) + (radius - 15) * cos(startAngle + sweepAngle),
+      (center.dy) + (radius - 15) * sin(startAngle + sweepAngle),
     );
 
     canvas.drawLine(center, needleEndPointOffset, needlePaint);

--- a/lib/src/painters/radial/segment_radial_gauge_painter.dart
+++ b/lib/src/painters/radial/segment_radial_gauge_painter.dart
@@ -182,13 +182,23 @@ class SegmentRadialGaugePainter extends CustomPainter {
     for (var value in valueTextList) {
       var valueLength = value.toStringAsFixed(decimalPlaces).length;
       bool needValueOffset = false;
-      double valueRnd = double.tryParse(value.toStringAsFixed(0)) ?? 0;
+      // double valueRnd = double.tryParse(value.toStringAsFixed(0)) ?? 0;
+      double valueRnd = 0;
+      int valueDP = 0;
+      for (valueDP; valueDP < 3; valueDP++) {
+        valueRnd = double.tryParse(value.toStringAsFixed(valueDP)) ?? 0;
+        // print("valueRnd: $valueRnd");
+        // print("value: $value");
+        if (valueRnd == value) {
+          break;
+        }
+      }
       double maxValueOffset = 7.5;
       if (valueRnd != value) {
         needValueOffset = true;
         maxValueOffset = 10;
       } else {
-        valueLength = value.toStringAsFixed(0).length;
+        valueLength = value.toStringAsFixed(valueDP).length;
       }
 
       final TextPainter valueTextPainter = TextPainter(
@@ -197,7 +207,7 @@ class SegmentRadialGaugePainter extends CustomPainter {
             color: Colors.black,
             fontSize: 12 - valueFontSizeOffset,
           ),
-          text: !needValueOffset ? value.toStringAsFixed(0)
+          text: !needValueOffset ? value.toStringAsFixed(valueDP)
               : value.toStringAsFixed(decimalPlaces),
         ),
         textDirection: TextDirection.ltr,
@@ -223,9 +233,16 @@ class SegmentRadialGaugePainter extends CustomPainter {
 
         valueTextPainter.paint(canvas, minValueScaleOffset);
       } else if (value == halfOfMinMaxValue) {
+        double valueLengthOffset = 0;
+        if (valueLength < 6) {
+          valueLengthOffset = valueLength.toDouble();
+        } else {
+          valueLengthOffset = valueLength.toDouble() / 3;
+        }
+
         var halfValueScaleOffset = Offset(
             (center.dx - ((value != 0) ? valueLength : 0) *
-                ((valueLength != 3) ? (valueLength / 5).ceil() : 2.5) - 2),
+                ((valueLength != 3) ? (valueLength / 5).ceil() : 2.5) - (2 + valueLengthOffset)),
             (center.dy) +
                 (radius - scaleSweepAngle - 30) *
                     sin(startAngle + scaleSweepAngle)

--- a/lib/src/radial_gauges/scale_radial_gauge.dart
+++ b/lib/src/radial_gauges/scale_radial_gauge.dart
@@ -24,12 +24,12 @@ class ScaleRadialGauge extends StatefulWidget {
     this.unit = const TextSpan(text: ''),
     Key? key,
   })  : assert(actualValue <= maxValue,
-        'actualValue must be less than or equal to maxValue'),
+            'actualValue must be less than or equal to maxValue'),
         assert(size >= 140, 'size must be greater than 75'),
         assert(actualValue >= minValue,
-        'actualValue must be greater than or equal to minValue'),
+            'actualValue must be greater than or equal to minValue'),
         assert(minValue < maxValue,
-        'maxValue must be greater than minValue'),
+            'maxValue must be greater than minValue'),
         super(key: key);
 
   /// Sets the minimum value of the gauge.
@@ -142,12 +142,12 @@ class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
             children: [
               widget.titlePosition == TitlePosition.top
                   ? SizedBox(
-                height: 20,
-                child: widget.title,
-              )
+                      height: 20,
+                      child: widget.title,
+                    )
                   : const SizedBox(
-                height: 20,
-              ),
+                      height: 20,
+                    ),
               SizedBox(
                 height: 200,
                 width: 200,
@@ -172,12 +172,12 @@ class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
               ),
               widget.titlePosition == TitlePosition.bottom
                   ? SizedBox(
-                height: 30,
-                child: widget.title,
-              )
+                      height: 30,
+                      child: widget.title,
+                    )
                   : const SizedBox(
-                height: 20,
-              )
+                      height: 20,
+                    )
             ],
           ),
         ),

--- a/lib/src/radial_gauges/segment_radial_gauge.dart
+++ b/lib/src/radial_gauges/segment_radial_gauge.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 
-import '../painters/radial/scale_radial_gauge_painter.dart';
+import '../painters/radial/segment_radial_gauge_painter.dart';
 import '../utils/constants.dart';
 import '../utils/enums.dart';
 import '../utils/radial_helper.dart';
+import '../utils/zone_segment.dart';
 
-class ScaleRadialGauge extends StatefulWidget {
+class SegmentRadialGauge extends StatefulWidget {
   /// Creates a scale Gauge.
   ///
   /// The [minValue] and [maxValue] must not be null.
-  const ScaleRadialGauge({
+  const SegmentRadialGauge({
     required this.maxValue,
     required this.actualValue,
     this.minValue = 0,
@@ -22,14 +23,31 @@ class ScaleRadialGauge extends StatefulWidget {
     this.isAnimate = true,
     this.animationDuration = kDefaultAnimationDuration,
     this.unit = const TextSpan(text: ''),
+    this.isPointer = false,
+    this.titleText = "",
+    this.title2Text = "",
+    this.segmentStartAngle = 120,
+    this.segmentSweepAngle = 300,
+    this.segmentMainNo = 10,
+    this.segmentSubNo = 2,
+    this.segmentList = const [],
     Key? key,
-  })  : assert(actualValue <= maxValue,
+  }) :
+        assert(actualValue <= maxValue,
         'actualValue must be less than or equal to maxValue'),
         assert(size >= 140, 'size must be greater than 75'),
         assert(actualValue >= minValue,
         'actualValue must be greater than or equal to minValue'),
         assert(minValue < maxValue,
         'maxValue must be greater than minValue'),
+        assert(segmentStartAngle > 0,
+        'segmentStartAngle must be greater than 0'),
+        assert(segmentSweepAngle > 0,
+        'segmentSweepAngle must be greater than 0'),
+        assert(segmentMainNo > 0,
+        'segmentMainNo must be greater than 0'),
+        assert(segmentSubNo > 0,
+        'segmentSubNo must be greater than 0'),
         super(key: key);
 
   /// Sets the minimum value of the gauge.
@@ -69,11 +87,35 @@ class ScaleRadialGauge extends StatefulWidget {
   /// Sets a duration in milliseconds to control the speed of the animation.
   final int animationDuration;
 
+  /// Toggle on and off Pointer Arc Animation.
+  final bool isPointer;
+
+  /// Set Title Text.
+  final String titleText;
+
+  /// Set Title2 Text.
+  final String title2Text;
+
+  /// Set Segment Start Angle
+  final double segmentStartAngle;
+
+  /// Set Segment Sweep Angle
+  final double segmentSweepAngle;
+
+  /// Set Main Segment Number
+  final int segmentMainNo;
+
+  /// Set Sub Segment Number
+  final int segmentSubNo;
+
+  /// Controls Zone Size & Color
+  final List<ZoneSegment> segmentList;
+
   @override
-  State<ScaleRadialGauge> createState() => _ScaleRadialGaugeState();
+  State<SegmentRadialGauge> createState() => _SegmentRadialGaugeState();
 }
 
-class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
+class _SegmentRadialGaugeState extends State<SegmentRadialGauge>
     with SingleTickerProviderStateMixin {
   late Animation<double> animation;
   late AnimationController animationController;
@@ -85,9 +127,11 @@ class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
         actualValue: widget.actualValue,
         maxValue: widget.maxValue,
         minValue: widget.minValue,
-        maxDegrees: 300);
+        maxDegrees: widget.segmentSweepAngle,
+    );
 
-    double upperBound = RadialHelper.degreesToRadians(300);
+    double upperBound = RadialHelper.degreesToRadians(
+        widget.segmentSweepAngle);
 
     animationController = AnimationController(
         duration: RadialHelper.getDuration(
@@ -121,13 +165,15 @@ class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
             actualValue: widget.actualValue,
             maxValue: widget.maxValue,
             minValue: widget.minValue,
-            maxDegrees: 300)) {
+            maxDegrees: widget.segmentSweepAngle,
+        )) {
       animationController.animateTo(
           RadialHelper.actualValueToSweepAngleRadian(
               actualValue: widget.actualValue,
               maxValue: widget.maxValue,
               minValue: widget.minValue,
-              maxDegrees: 300),
+              maxDegrees: widget.segmentSweepAngle,
+          ),
           duration: RadialHelper.getDuration(
               isAnimate: widget.isAnimate,
               userMilliseconds: widget.animationDuration));
@@ -154,7 +200,7 @@ class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
                 child: Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: CustomPaint(
-                    painter: ScaleRadialGaugePainter(
+                    painter: SegmentRadialGaugePainter(
                       sweepAngle: animationController.value,
                       pointerColor: widget.pointerColor,
                       needleColor: widget.needleColor,
@@ -163,6 +209,14 @@ class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
                       actualValue: widget.actualValue,
                       decimalPlaces: widget.decimalPlaces,
                       unit: widget.unit,
+                      isPointer: widget.isPointer,
+                      titleText: widget.titleText,
+                      title2Text: widget.title2Text,
+                      segmentStartAngle: widget.segmentStartAngle,
+                      segmentSweepAngle: widget.segmentSweepAngle,
+                      segmentMainNo: widget.segmentMainNo,
+                      segmentSubNo: widget.segmentSubNo,
+                      segmentList: widget.segmentList,
                     ),
                   ),
                 ),

--- a/lib/src/radial_gauges/segment_radial_gauge.dart
+++ b/lib/src/radial_gauges/segment_radial_gauge.dart
@@ -34,20 +34,20 @@ class SegmentRadialGauge extends StatefulWidget {
     Key? key,
   }) :
         assert(actualValue <= maxValue,
-        'actualValue must be less than or equal to maxValue'),
+            'actualValue must be less than or equal to maxValue'),
         assert(size >= 140, 'size must be greater than 75'),
         assert(actualValue >= minValue,
-        'actualValue must be greater than or equal to minValue'),
+            'actualValue must be greater than or equal to minValue'),
         assert(minValue < maxValue,
-        'maxValue must be greater than minValue'),
+            'maxValue must be greater than minValue'),
         assert(segmentStartAngle > 0,
-        'segmentStartAngle must be greater than 0'),
+            'segmentStartAngle must be greater than 0'),
         assert(segmentSweepAngle > 0,
-        'segmentSweepAngle must be greater than 0'),
+            'segmentSweepAngle must be greater than 0'),
         assert(segmentMainNo > 0,
-        'segmentMainNo must be greater than 0'),
+            'segmentMainNo must be greater than 0'),
         assert(segmentSubNo > 0,
-        'segmentSubNo must be greater than 0'),
+            'segmentSubNo must be greater than 0'),
         super(key: key);
 
   /// Sets the minimum value of the gauge.
@@ -183,57 +183,55 @@ class _SegmentRadialGaugeState extends State<SegmentRadialGauge>
       width: widget.size,
       height: widget.size,
       child: FittedBox(
-        child: SizedBox(
-          child: Column(
-            children: [
-              widget.titlePosition == TitlePosition.top
-                  ? SizedBox(
-                height: 20,
-                child: widget.title,
-              )
-                  : const SizedBox(
-                height: 20,
-              ),
-              SizedBox(
-                height: 200,
-                width: 200,
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: CustomPaint(
-                    painter: SegmentRadialGaugePainter(
-                      sweepAngle: animationController.value,
-                      pointerColor: widget.pointerColor,
-                      needleColor: widget.needleColor,
-                      minValue: widget.minValue,
-                      maxValue: widget.maxValue,
-                      actualValue: widget.actualValue,
-                      decimalPlaces: widget.decimalPlaces,
-                      unit: widget.unit,
-                      isPointer: widget.isPointer,
-                      titleText: widget.titleText,
-                      title2Text: widget.title2Text,
-                      segmentStartAngle: widget.segmentStartAngle,
-                      segmentSweepAngle: widget.segmentSweepAngle,
-                      segmentMainNo: widget.segmentMainNo,
-                      segmentSubNo: widget.segmentSubNo,
-                      segmentList: widget.segmentList,
-                    ),
+        child: Column(
+          children: [
+            widget.titlePosition == TitlePosition.top
+                ? SizedBox(
+              height: 20,
+              child: widget.title,
+            )
+                : const SizedBox(
+              height: 20,
+            ),
+            SizedBox(
+              height: 200,
+              width: 200,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: CustomPaint(
+                  painter: SegmentRadialGaugePainter(
+                    sweepAngle: animationController.value,
+                    pointerColor: widget.pointerColor,
+                    needleColor: widget.needleColor,
+                    minValue: widget.minValue,
+                    maxValue: widget.maxValue,
+                    actualValue: widget.actualValue,
+                    decimalPlaces: widget.decimalPlaces,
+                    unit: widget.unit,
+                    isPointer: widget.isPointer,
+                    titleText: widget.titleText,
+                    title2Text: widget.title2Text,
+                    segmentStartAngle: widget.segmentStartAngle,
+                    segmentSweepAngle: widget.segmentSweepAngle,
+                    segmentMainNo: widget.segmentMainNo,
+                    segmentSubNo: widget.segmentSubNo,
+                    segmentList: widget.segmentList,
                   ),
                 ),
               ),
-              const SizedBox(
-                height: 10,
-              ),
-              widget.titlePosition == TitlePosition.bottom
-                  ? SizedBox(
-                height: 30,
-                child: widget.title,
-              )
-                  : const SizedBox(
-                height: 20,
-              )
-            ],
-          ),
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+            widget.titlePosition == TitlePosition.bottom
+                ? SizedBox(
+              height: 30,
+              child: widget.title,
+            )
+                : const SizedBox(
+              height: 20,
+            )
+          ],
         ),
       ),
     );

--- a/lib/src/utils/abstract_classes.dart
+++ b/lib/src/utils/abstract_classes.dart
@@ -22,6 +22,8 @@ abstract class LinearCustomPainter extends CustomPainter {
     required this.minorTickStrokeWidth,
     required this.actualValueTextStyle,
     required this.majorTicksValueTextStyle,
+    required this.majorTicksDecimalPlace,
+    required this.unitString,
   });
 
   /// Sets the minimum value of the gauge.
@@ -72,14 +74,22 @@ abstract class LinearCustomPainter extends CustomPainter {
   /// Orient the gauge vertically or horizontally.
   final GaugeOrientation gaugeOrientation;
 
+  /// Sets the decimal place of the majorTicks Value
+  final int majorTicksDecimalPlace;
+
+  /// Set the Unit of value
+  final String unitString;
+
   ///find scale lowest value
   double getScaleLowerLimit(Size size) {
     switch (gaugeOrientation) {
       case GaugeOrientation.horizontal:
-        return size.height * kLowerScaleLimitHorizontal;
+        return size.width * kLowerScaleLimitHorizontal;
+        // return size.height * kLowerScaleLimitHorizontal;
 
       case GaugeOrientation.vertical:
         return size.height / kLowerScaleLimitVertical;
+        // return size.height / kLowerScaleLimitVertical;
     }
   }
 
@@ -87,9 +97,11 @@ abstract class LinearCustomPainter extends CustomPainter {
   double getScaleUpperLimit(Size size) {
     switch (gaugeOrientation) {
       case GaugeOrientation.horizontal:
-        return size.height * kUpperScaleLimitHorizontal;
+        return size.width * kUpperScaleLimitHorizontal;
+        // return size.height * kUpperScaleLimitHorizontal;
 
       case GaugeOrientation.vertical:
+        return size.height / kUpperScaleLimitVertical / 1.7;
         return size.height / kUpperScaleLimitVertical;
     }
   }
@@ -125,10 +137,12 @@ abstract class LinearCustomPainter extends CustomPainter {
     final interval = getScaleInterval(size);
 
     var majorTickMarkPosition = getScaleLowerLimit(size);
+    // print('majorTickMarkPosition: $majorTickMarkPosition');
 
     for (var i = 0; i < (divisions + 1); i++) {
       final Offset majorTickMarksEndPoint =
           Offset((size.width / 1.8) + gaugeStrokeWidth, majorTickMarkPosition);
+          // Offset((size.width / 1.622) + gaugeStrokeWidth, majorTickMarkPosition);
 
       final Offset majorTickMarksStartPoint = Offset(
           (size.width / 2.0) - gaugeStrokeWidth / 2, majorTickMarkPosition);
@@ -146,6 +160,7 @@ abstract class LinearCustomPainter extends CustomPainter {
   void drawMinorTickMarks({required Canvas canvas, required Size size}) {
     /// the total length of the scale
     final scaleLength = getScaleLength(size);
+    // print(scaleLength);
 
     /// the minor division
     /// multiplying the max division by 5 to find the total divisions within the scale
@@ -153,11 +168,16 @@ abstract class LinearCustomPainter extends CustomPainter {
 
     /// finds the distance needed between each [MinorDivisions]
     final interval = scaleLength / minorDivisions;
+    // print(getScaleUpperLimit(size));
+    // print(interval);
 
     double minorTickMarkPosition = 0;
     switch (gaugeOrientation) {
       case GaugeOrientation.horizontal:
         minorTickMarkPosition = getScaleLowerLimit(size);
+        // minorTickMarkPosition = size.width * kLowerScaleLimitHorizontal;
+        // print('getScaleLowerLimit(size): ${getScaleLowerLimit(size)}');
+        // print(size.width);
         break;
       case GaugeOrientation.vertical:
         minorTickMarkPosition = size.height / kLowerScaleLimitVertical;
@@ -167,6 +187,8 @@ abstract class LinearCustomPainter extends CustomPainter {
     for (var i = 0; i < (minorDivisions + 1); i++) {
       final Offset minorTickMarksEndPoint =
           Offset((size.width / 1.9) + gaugeStrokeWidth, minorTickMarkPosition);
+      // final Offset minorTickMarksEndPoint =
+      //     Offset((size.width / 1.9) + gaugeStrokeWidth, minorTickMarkPosition);
 
       final Offset minorTickMarksStartPoint =
           Offset(size.width / 2, minorTickMarkPosition);
@@ -194,7 +216,7 @@ abstract class LinearCustomPainter extends CustomPainter {
       // multiply the interval by the division to find the value at the division.
       var value = (i * valueInterval) + minValue;
 
-      var stringValue = value.toStringAsFixed(decimalPlaces);
+      var stringValue = value.toStringAsFixed(majorTicksDecimalPlace);
 
       // sets the paint properties of the tick value.
       final majorTickValuePainter = TextPainter(
@@ -209,6 +231,11 @@ abstract class LinearCustomPainter extends CustomPainter {
 
           /// Find the position of the ticks
 
+          // final Offset majorTickValuePosition = Offset(
+          //     (size.width / 1.65) +
+          //         gaugeStrokeWidth -
+          //         (majorTickValuePainter.width / 2),
+          //     majorTickMarkPosition);
           final Offset majorTickValuePosition = Offset(
               (size.width / 1.65) +
                   gaugeStrokeWidth -
@@ -230,7 +257,8 @@ abstract class LinearCustomPainter extends CustomPainter {
 
           /// Find the position of the ticks
           final Offset majorTickValuePosition = Offset(
-              (size.width / 1.7) + gaugeStrokeWidth, majorTickMarkPosition);
+              (size.width / 1.575) + gaugeStrokeWidth, majorTickMarkPosition + 3);
+              // (size.width / 1.7) + gaugeStrokeWidth, majorTickMarkPosition);
           majorTickValuePainter.paint(canvas, majorTickValuePosition);
           break;
       }
@@ -272,7 +300,10 @@ abstract class LinearCustomPainter extends CustomPainter {
       case GaugeOrientation.horizontal:
         final Offset pointerIconPosition = Offset(
             (size.width / 2.5) - pointerIconPainter.width + 30,
-            getActualValuePosition(size) - (pointerIconPainter.height / 2));
+            getActualValuePosition(size) - (pointerIconPainter.height / 2) - 0.7);
+        // final Offset pointerIconPosition = Offset(
+        //     (size.width / 2.5) - pointerIconPainter.width + 30,
+        //     getActualValuePosition(size) - (pointerIconPainter.height / 2));
         final pivot = pointerIconPainter.size.center(pointerIconPosition);
         canvas.save();
         canvas.translate(pivot.dx, pivot.dy);
@@ -283,8 +314,10 @@ abstract class LinearCustomPainter extends CustomPainter {
         break;
       case GaugeOrientation.vertical:
         final Offset pointerIconPosition = Offset(
-            (size.width / 2.5) - pointerIconPainter.width + 30,
-            getActualValuePosition(size) - (pointerIconPainter.height / 2));
+            // (size.width / 2.5) - pointerIconPainter.width + 30,
+            // getActualValuePosition(size) - (pointerIconPainter.height / 2));
+            (size.width / 3.25) - pointerIconPainter.width + 30,
+            getActualValuePosition(size) - (pointerIconPainter.height / 2) - 1);
         pointerIconPainter.paint(canvas, pointerIconPosition);
         break;
     }
@@ -294,20 +327,27 @@ abstract class LinearCustomPainter extends CustomPainter {
   void drawActualValue(Canvas canvas, Size size) {
     final actualValuePainter = TextPainter(
       text: TextSpan(
-        text: actualValue.toStringAsFixed(decimalPlaces),
+        text: '${actualValue.toStringAsFixed(decimalPlaces)}$unitString',
         style: actualValueTextStyle,
       ),
       textDirection: TextDirection.ltr,
     )..layout();
 
-    final Offset actualValuePosition = Offset(
-      (size.width / 2.8) -
-          actualValuePainter.width +
-          (20 - ((pointerIcon.size ?? 24.0) - 20)),
-      getActualValuePosition(size) - (actualValuePainter.height / 2),
-    );
+    // final Offset actualValuePosition = Offset(
+    //   (size.width / 2.8) -
+    //       actualValuePainter.width +
+    //       (20 - ((pointerIcon.size ?? 24.0) - 20)),
+    //   getActualValuePosition(size) - (actualValuePainter.height / 2),
+    // );
+
     switch (gaugeOrientation) {
       case GaugeOrientation.horizontal:
+        final Offset actualValuePosition = Offset(
+          (size.width / 2.7) -
+              actualValuePainter.width +
+              (20 - ((pointerIcon.size ?? 24.0) - 20)),
+          getActualValuePosition(size) - (actualValuePainter.height / 2),
+        );
         final pivot = actualValuePainter.size.center(actualValuePosition);
         canvas.save();
         canvas.translate(pivot.dx, pivot.dy);
@@ -317,6 +357,12 @@ abstract class LinearCustomPainter extends CustomPainter {
         canvas.restore();
         break;
       case GaugeOrientation.vertical:
+        final Offset actualValuePosition = Offset(
+          (size.width / 4) -
+              actualValuePainter.width +
+              (20 - ((pointerIcon.size ?? 24.0) - 20)),
+          getActualValuePosition(size) - (actualValuePainter.height / 2),
+        );
         actualValuePainter.paint(canvas, actualValuePosition);
     }
   }
@@ -336,9 +382,11 @@ abstract class LinearCustomPainter extends CustomPainter {
     switch (gaugeOrientation) {
       case GaugeOrientation.horizontal:
         if (titlePosition == TitlePosition.top) {
-          titlePositionOffset = Offset((size.width / 6), size.height / 2);
+          // titlePositionOffset = Offset((size.width / 6), size.height / 2);
+          titlePositionOffset = Offset(size.width / 6, size.height);
         } else {
-          titlePositionOffset = Offset((size.width / 1.8), size.height / 2);
+          // titlePositionOffset = Offset(size.width / 1.8, size.height / 2);
+          titlePositionOffset = Offset(size.width / 1.9, size.height);
         }
         final pivot = titlePainter.size.center(titlePositionOffset);
         canvas.save();
@@ -353,7 +401,8 @@ abstract class LinearCustomPainter extends CustomPainter {
         final halfTextWidth = titlePainter.width / 2;
         double titleHeight;
         if (titlePosition.name == 'top') {
-          titleHeight = getScaleUpperLimit(size) - 50;
+          // titleHeight = getScaleUpperLimit(size) - 50;
+          titleHeight = getScaleUpperLimit(size) - 40;
 
           /// Subtract this value from half width of canvas to center title.
           final titlePositionOffset =
@@ -375,7 +424,8 @@ abstract class LinearCustomPainter extends CustomPainter {
         canvas.save();
         canvas.translate(size.width / 2, size.height / 2);
         canvas.rotate(RadialHelper.degreesToRadians(90));
-        canvas.translate(-size.width / 2, -size.height / 2);
+        canvas.translate(-size.width / 2, -size.height);
+        // canvas.translate(-size.width / 2, -size.height / 2);
 
         break;
 
@@ -424,13 +474,16 @@ abstract class LinearCustomGauge extends StatefulWidget {
     required this.gaugeOrientation,
     required this.decimalPlaces,
     required this.isAnimate,
-    required this.milliseconds,
+    required this.animationDuration,
     required this.gaugeStrokeWidth,
     required this.rangeStrokeWidth,
     required this.majorTickStrokeWidth,
     required this.minorTickStrokeWidth,
     required this.actualValueTextStyle,
     required this.majorTicksValueTextStyle,
+    required this.majorTicksDecimalPlace,
+    required this.unitString,
+    required this.size,
   })  : assert(actualValue <= maxValue,
             'actualValue must be less than or equal to maxValue'),
         assert(actualValue >= minValue,
@@ -471,7 +524,7 @@ abstract class LinearCustomGauge extends StatefulWidget {
   final bool isAnimate;
 
   /// Sets a duration in milliseconds to control the speed of the animation.
-  final int milliseconds;
+  final int animationDuration;
 
   /// Sets the stroke width of the ranges.
   final double rangeStrokeWidth;
@@ -490,4 +543,15 @@ abstract class LinearCustomGauge extends StatefulWidget {
 
   /// Sets the [TextStyle] for the majorTicksValue.
   final TextStyle majorTicksValueTextStyle;
+
+  /// Sets the decimal place of the majorTicks Value
+  final int majorTicksDecimalPlace;
+
+  /// Set the Unit of value
+  final String unitString;
+
+  /// Sets the width and height of the gauge.
+  ///
+  /// If the parent widget has unconstrained height like a [ListView], wrap the gauge in a [SizedBox] to better control it's size
+  final double size;
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -3,3 +3,4 @@ export 'constants.dart';
 export 'enums.dart';
 export 'radial_helper.dart';
 export 'range.dart';
+export 'zone_segment.dart';

--- a/lib/src/utils/zone_segment.dart
+++ b/lib/src/utils/zone_segment.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class ZoneSegment {
+  final double size;
+  final Color color;
+
+  ZoneSegment({
+    required this.size,
+    required this.color
+  });
+
+  // ZoneSegment copyWith({
+  //   double? size,
+  //   Color? color,
+  // }) {
+  //   return ZoneSegment(
+  //     size: size ?? this.size,
+  //     color: color ?? this.color,
+  //   );
+  // }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added a Segment Radial Gauge which can show different segment color & size
- Edited getScale function of Scale Radial Gauge for negative minValue usage
- Added Example Widget in example/lib/main.dart

**- How I did it**

- The Segment Radial Gauge is developed from Scale Radial Gauge, using Arc to represent the Segment
- Using both minValue and maxValue in getScale for allowing negative minValue

**- How to verify it**

- Please try example
