### PR TITLE
fix: excessive builds

### DIFF
--- a/lib/src/linear_gauges/simple_linear_gauge.dart
+++ b/lib/src/linear_gauges/simple_linear_gauge.dart
@@ -86,10 +86,16 @@ class _SimpleLinearGaugeState extends State<SimpleLinearGauge>
   }
 
   @override
-  Widget build(BuildContext context) {
+  void didUpdateWidget(covariant SimpleLinearGauge oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
     if (animationController.value != widget.actualValue) {
       animationController.animateTo(widget.actualValue);
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return CustomPaint(
       child: SizedBox.expand(),
       painter: SimpleLinearGaugePainter(

--- a/lib/src/radial_gauges/range_radial_gauge.dart
+++ b/lib/src/radial_gauges/range_radial_gauge.dart
@@ -137,24 +137,29 @@ class _RangeRadialGaugeState extends State<RangeRadialGauge>
   }
 
   @override
-  Widget build(BuildContext context) {
-    if (animationController.value !=
-        RadialHelper.actualValueToSweepAngleRadian(
-            minValue: widget.minValue,
-            actualValue: widget.actualValue,
-            maxValue: widget.maxValue,
-            maxDegrees: widget.maxDegree)) {
-      animationController.animateTo(
-          RadialHelper.actualValueToSweepAngleRadian(
-              minValue: widget.minValue,
-              actualValue: widget.actualValue,
-              maxValue: widget.maxValue,
-              maxDegrees: widget.maxDegree),
-          duration: RadialHelper.getDuration(
-              isAnimate: widget.isAnimate,
-              userMilliseconds: widget.animationDuration));
-    }
+  void didUpdateWidget(covariant RangeRadialGauge oldWidget) {
+    super.didUpdateWidget(oldWidget);
 
+    final sweepAngleRadian = RadialHelper.actualValueToSweepAngleRadian(
+      minValue: widget.minValue,
+      actualValue: widget.actualValue,
+      maxValue: widget.maxValue,
+      maxDegrees: widget.maxDegree,
+    );
+
+    if (animationController.value != sweepAngleRadian) {
+      animationController.animateTo(
+        sweepAngleRadian,
+        duration: RadialHelper.getDuration(
+          isAnimate: widget.isAnimate,
+          userMilliseconds: widget.animationDuration,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return SizedBox(
       width: widget.size,
       height: widget.size,

--- a/lib/src/radial_gauges/scale_radial_gauge.dart
+++ b/lib/src/radial_gauges/scale_radial_gauge.dart
@@ -113,24 +113,27 @@ class _ScaleRadialGaugeState extends State<ScaleRadialGauge>
   }
 
   @override
-  Widget build(BuildContext context) {
-    if (animationController.value !=
-        RadialHelper.actualValueToSweepAngleRadian(
-            actualValue: widget.actualValue,
-            maxValue: widget.maxValue,
-            minValue: widget.minValue,
-            maxDegrees: 300)) {
-      animationController.animateTo(
-          RadialHelper.actualValueToSweepAngleRadian(
-              actualValue: widget.actualValue,
-              maxValue: widget.maxValue,
-              minValue: widget.minValue,
-              maxDegrees: 300),
-          duration: RadialHelper.getDuration(
-              isAnimate: widget.isAnimate,
-              userMilliseconds: widget.animationDuration));
-    }
+  void didUpdateWidget(covariant ScaleRadialGauge oldWidget) {
+    super.didUpdateWidget(oldWidget);
 
+    final sweepAngleRadian = RadialHelper.actualValueToSweepAngleRadian(
+      actualValue: widget.actualValue,
+      maxValue: widget.maxValue,
+      minValue: widget.minValue,
+      maxDegrees: 300,
+    );
+    if (animationController.value != sweepAngleRadian) {
+      animationController.animateTo(
+        sweepAngleRadian,
+        duration: RadialHelper.getDuration(
+            isAnimate: widget.isAnimate,
+            userMilliseconds: widget.animationDuration),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return SizedBox(
       width: widget.size,
       height: widget.size,

--- a/lib/src/radial_gauges/simple_radial_gauge.dart
+++ b/lib/src/radial_gauges/simple_radial_gauge.dart
@@ -116,22 +116,22 @@ class _SimpleRadialGaugeState extends State<SimpleRadialGauge>
   }
 
   @override
-  Widget build(BuildContext context) {
-    if (animationController.value !=
-        RadialHelper.actualValueToSweepAngleRadian(
-            minValue: widget.minValue,
-            actualValue: widget.actualValue,
-            maxValue: widget.maxValue)) {
-      animationController.animateTo(
-          RadialHelper.actualValueToSweepAngleRadian(
-              minValue: widget.minValue,
-              actualValue: widget.actualValue,
-              maxValue: widget.maxValue),
-          duration: RadialHelper.getDuration(
-              isAnimate: widget.isAnimate,
-              userMilliseconds: widget.animationDuration));
-    }
+  void didUpdateWidget(covariant SimpleRadialGauge oldWidget) {
+    super.didUpdateWidget(oldWidget);
 
+    final sweepAngleRadian = RadialHelper.actualValueToSweepAngleRadian(
+      minValue: widget.minValue,
+      actualValue: widget.actualValue,
+      maxValue: widget.maxValue,
+    );
+
+    if (animationController.value != sweepAngleRadian) {
+      animationController.animateTo(sweepAngleRadian);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return SizedBox(
       width: widget.size,
       height: widget.size,


### PR DESCRIPTION
If the guages animate from any value to 0 there is a bit of pointer color painted which disappears after about 20 seconds. 
The following pr attempts to fix this. 

**- What I did**
Rebuild gauges only once when values are updated.

**- How I did it**
Moved animationController.animateTo from build into didUpdateWidget

changlelog:
Stop continuous rebuilds. 